### PR TITLE
Highlight blink change

### DIFF
--- a/app/src/resources/main.css
+++ b/app/src/resources/main.css
@@ -22,7 +22,7 @@
 
 @keyframes highlight-blink {
 	from { background-color: var(--color-bg--target); }
-	to   { background-color: var(--color-bg); }
+	to   {}
 }
 
 @keyframes card-flip--front {
@@ -446,11 +446,13 @@ tr:target {
 	scroll-margin-top: 104px;
 }
 
-section:target {
+section.anim-highlight-blink,
+section.anim-highlight-blink th,
+section.anim-highlight-blink td {
+	scroll-margin-top: 3em;
 	animation-name: highlight-blink;
 	animation-duration: 1s;
 	animation-timing-function: ease-in;
-	animation-fill-mode: forwards;
 }
 
 /* in-game objects image sprite */

--- a/app/src/resources/main.js
+++ b/app/src/resources/main.js
@@ -171,15 +171,13 @@ const SectionHighlight = (function () {
 	
 	Object.assign(SectionHighlight.prototype, {
 		init: function () {
-			const sections = document.querySelectorAll("section[id]");
-			const attrSelectors = [];
-			sections.forEach((section) => attrSelectors.push('[href="#' + section.id + '"]'));
-			
-			const links = document.querySelectorAll("a:is(" + attrSelectors.join(",") + ")");
-			links.forEach((link) => link.addEventListener("click", this.addAnimClass));
+			document.querySelector("#Table_of_Contents > ul").addEventListener("click", this.addAnimClass);
+
 		},
 		
 		addAnimClass: function (event) {
+			if (event.target.tagName !== "A" || !event.target.href) {return};
+
 			const section = document.getElementById(event.target.getAttribute("href").slice(1));
 			if (!section.classList.contains("anim-highlight-blink")) {
 				section.classList.add("anim-highlight-blink");

--- a/app/src/resources/main.js
+++ b/app/src/resources/main.js
@@ -164,6 +164,44 @@ const DivinersDeck = (function () {
 	return DivinersDeck;
 })();
 
+const SectionHighlight = (function () {
+	function SectionHighlight() {
+		// empty
+	};
+	
+	Object.assign(SectionHighlight.prototype, {
+		init: function () {
+			const sections = document.querySelectorAll("section[id]");
+			const attrSelectors = [];
+			sections.forEach((section) => attrSelectors.push('[href="#' + section.id + '"]'));
+			
+			const links = document.querySelectorAll("a:is(" + attrSelectors.join(",") + ")");
+			links.forEach((link) => link.addEventListener("click", this.addAnimClass));
+		},
+		
+		addAnimClass: function (event) {
+			const section = document.getElementById(event.target.getAttribute("href").slice(1));
+			if (!section.classList.contains("anim-highlight-blink")) {
+				section.classList.add("anim-highlight-blink");
+				section.addEventListener("animationend", cleanup);
+				section.addEventListener("animationcancel", cleanup);
+			};
+		},
+		
+		cleanup: function (event) {
+			if(event.animationName === "highlight-blink") {
+				event.target.classList.remove("anim-highlight-blink");
+				event.target.removeEventListener("animationend", cleanup);
+				event.target.removeEventListener("animationcancel", cleanup);
+			};
+		}
+	});
+	
+	const cleanup = SectionHighlight.prototype.cleanup;
+	
+	return SectionHighlight;
+})();
+
 /**
  * Scroll to top *without* adding the anchor to the URL, as a javascript supported improvement over the no-script base functionality
  * @type {ScrollToTop}
@@ -190,5 +228,6 @@ const ScrollToTop = (function () {
 document.addEventListener('DOMContentLoaded', function() {
 	(new CopyID()).init();
 	(new DivinersDeck()).init();
+	(new SectionHighlight()).init();
 	(new ScrollToTop()).init();
 });


### PR DESCRIPTION
The highlight-blink animation is a bit broken. It highlighted before the whole section of content it refers to to draw attention, but it's lost that when the other elements (tables) had their background colors.
Extending the animation to additionally target the table data looks fine. I've tested targeting all children of the section element, but it looked terrible by comparison. There's also a small `scroll-margin-top` as padding when they get scrolled to the content like the other links.

I've tried to move the animation to a CSS class instead of `:target`. It's mostly due to the limitation where the animation wouldn't play again if the animation had already played before and its selector hadn't changed. I tried to implement it on js to match the others, but I don't know how successful it was. I couldn't take advantage of the object-this chaining like the others and ended up relying on a locally-scoped variable instead.